### PR TITLE
Add Colab demo for D3Net and fix inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Identifying the influence of training data for data cleansing can improve the ac
 
 ### [**D3Net: Densely connected multidilated convolutional networks for dense prediction tasks**](https://arxiv.org/abs/2011.11844) ([Code](./d3net))
 
-This is the official NNabla implementation of D3Net, densely connected multidilated convolutional networks for dense prediction tasks which is acceped at CVPR 2021.
+This is the official NNabla implementation of D3Net, densely connected multidilated convolutional networks for dense prediction tasks which is accepted at CVPR 2021.
 
->Takahashi, Naoya, and Yuki Mitsufuji. "Densely connected multidilated convolutional networks for dense prediction tasks." arXiv preprint arXiv:2011.11844 (2020).
+>Takahashi, Naoya, and Yuki Mitsufuji. "Densely connected multidilated convolutional networks for dense prediction tasks." arXiv preprint [arXiv:2011.11844](https://arxiv.org/abs/2011.11844) (2021).
 
 Tasks that involve high-resolution dense prediction require a modeling of both local and galobal patterns in a large input field. Although the local and global structures often depend on each other and their simultaneous modeling is important, many convolutional neural network (CNN)- based approaches interchange representations in different resolutions only a few times. In this paper, we claim the importance of a dense simultaneous modeling of multiresolution representation and propose a novel CNN architecture called densely connected multidilated DenseNet (D3Net). D3Net involves a novel multidilated convolution that has different dilation factors in a single layer to model different resolutions simultaneously. By combining the multidilated convolution with the DenseNet architecture, D3Net incorporates multiresolution learning with an exponentially growing receptive field in almost all layers, while avoiding the aliasing problem that occurs when we naively incorporate the dilated convolution in DenseNet. Experiments on the image semantic segmentation task using Cityscapes and the audio source separation task using MUSDB18 show that the proposed method has superior performance over stateof-the-art methods.

--- a/d3net/README.md
+++ b/d3net/README.md
@@ -1,7 +1,7 @@
 # D3Net: Densely connected multidilated convolutional networks for dense prediction tasks
 
 This is the official NNabla implementation of D3Net, densely connected multidilated convolutional networks for dense prediction tasks ([arXiv](https://arxiv.org/abs/2011.11844),)
-which is acceped at CVPR 2021.
+which is accepted at CVPR 2021.
 
 D3Net is demonstrated on the Music Source Separation and Semantic Segmentation tasks. Please follow the links below to explore inference code and pre-trained models:
 * [Music Source Separation](./music-source-separation)

--- a/d3net/music-source-separation/D3Net-MSS.ipynb
+++ b/d3net/music-source-separation/D3Net-MSS.ipynb
@@ -1,0 +1,118 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Code/Environment Preparation\n",
+    "\n",
+    "Let's start by installing nnabla and other required packages first. If you're running on Colab, make sure that your Runtime setting is set as GPU. If not, that can be set up from the top menu (Runtime → change runtime type). Then click Connect on the top right-hand side of the screen before you start."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install soundfile librosa nnabla-ext-cuda100\n",
+    "!pip install --upgrade PyYAML"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Next, clone the code from sony/ai-research-code repository, and then download the [pre-trained weights](https://nnabla.org/pretrained-models/ai-research-code/d3net/mss/d3net-mss.h5) to test on music files(only wav format)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!git clone https://github.com/sony/ai-research-code.git\n",
+    "%cd ai-research-code/d3net/music-source-separation\n",
+    "!wget https://nnabla.org/pretrained-models/ai-research-code/d3net/mss/d3net-mss.h5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing\n",
+    "\n",
+    "If you do not have sample music files, such files can be downloaded from [this link](https://www.ee.columbia.edu/~dpwe/sounds/music/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#To upload music files from local machine\n",
+    "\n",
+    "from google.colab import files\n",
+    "uploaded_file = files.upload()\n",
+    "filename = list(uploaded_file.keys())[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python separate.py  -i $filename -o ./output/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Listen To Audio Seperated Files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "cellView": "form"
+   },
+   "outputs": [],
+   "source": [
+    "#@title Choose a separate track\n",
+    "\n",
+    "sub_folder_name = filename.split('.wav')[0].split('/')[-1]\n",
+    "track = 'vocals' #@param [\"bass\", \"drums\", \"vocals\", \"other\"]\n",
+    "import IPython.display as ipd\n",
+    "ipd.Audio(f'output/{sub_folder_name}/{track}.wav')"
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/d3net/music-source-separation/README.md
+++ b/d3net/music-source-separation/README.md
@@ -2,6 +2,11 @@
 
 This is inference code for D3Net based music source separation.
 
+## Quick Music Source Separation Demo by D3Net
+
+From the Colab link below, you can try using D3Net to generate and listen to separated audio sources of your audio music file. Please give it a try!
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/sony/ai-research-code/blob/master/d3net/music-source-separation/D3Net-MSS.ipynb)
 
 ## Getting started
 

--- a/d3net/music-source-separation/model.py
+++ b/d3net/music-source-separation/model.py
@@ -175,7 +175,7 @@ def md3_block_ds(inp, in_channels, ks, n_layers, n_blocks, comp_rates, kernel_si
     with nn.parameter_scope(name + '/us_layers'):
         for k, nl, comp, b, i in zip(ks[ds_len + 1:], n_layers[ds_len + 1:], comp_rates[ds_len:], n_blocks[ds_len:], range(ds_len)):
             with nn.parameter_scope('upsample%s' % i):
-                out = upsampling_layer(out, n_channels, comp)
+                out = upsampling_layer(out, n_channels, comp, test)
                 out = F.concatenate(out, ds[cnt], axis=1)
                 cnt += 1
             if comp < 1.:

--- a/d3net/music-source-separation/util.py
+++ b/d3net/music-source-separation/util.py
@@ -145,7 +145,7 @@ def calc_output_overlap_add(inp, hparams, out_ch=None, ch_flip_average=False):
         if ch_flip_average:
             inp_ = np.concatenate([inp_, inp_[:, :, ::-1, :]], axis=0)
 
-        out_ = d3_net(nn.Variable.from_numpy_array(inp_), hparams)
+        out_ = d3_net(nn.Variable.from_numpy_array(inp_), hparams, test=True)
         out_.forward(clear_buffer=True)
         out_ = out_.data.data
 


### PR DESCRIPTION
This PR adds and modifies the following items for D3Net music source separation.
* Add a Colab demo
* Fix inference script to properly use the test option in BNs. 