### PR TITLE
add/fix required argument

### DIFF
--- a/x-umx/X-UMX.ipynb
+++ b/x-umx/X-UMX.ipynb
@@ -64,7 +64,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "!python test.py  --inputs  $filename --outdir ./results/"
+        "!python test.py --inputs $filename --out-dir results --model models/x-umx.h5"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Probably due to the recent change, Colab interactive demo is not working, so I fixed the issue.

What I did:
* fix an argument name `--outdir` -> `--out-dir`
* add a required argument `--model`

Confirmed Colab demo works by these changes.